### PR TITLE
Only the voice is needed, gender and language code are linked to it

### DIFF
--- a/rhasspysupervisor/__init__.py
+++ b/rhasspysupervisor/__init__.py
@@ -2155,12 +2155,8 @@ def get_text_to_speech(
 
     if tts_system == "wavenet":
 
-        voice = str(profile.get("text_to_speech.wavenet.voice", "Wavenet-C")).strip()
-        gender = str(profile.get("text_to_speech.wavenet.gender", "FEMALE")).strip()
+        voice = str(profile.get("text_to_speech.wavenet.voice", "en-US-Wavenet-C")).strip()
         sample_rate = str(profile.get("text_to_speech.wavenet.sample_rate", 22050))
-        language_code = str(
-            profile.get("text_to_speech.wavenet.language_code", "en-US")
-        ).strip()
 
         credentials_json = profile.get("text_to_speech.wavenet.credentials_json")
         if not credentials_json:
@@ -2180,12 +2176,8 @@ def get_text_to_speech(
             shlex.quote(str(write_path(profile, cache_dir))),
             "--voice",
             shlex.quote(voice),
-            "--gender",
-            shlex.quote(gender),
             "--sample-rate",
             shlex.quote(sample_rate),
-            "--language-code",
-            shlex.quote(language_code),
         ]
 
         add_standard_args(

--- a/rhasspysupervisor/__init__.py
+++ b/rhasspysupervisor/__init__.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from urllib.parse import urljoin
 
 import yaml
-
 from rhasspyprofile import Profile
 
 _LOGGER = logging.getLogger("rhasspysupervisor")

--- a/rhasspysupervisor/__init__.py
+++ b/rhasspysupervisor/__init__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from urllib.parse import urljoin
 
 import yaml
+
 from rhasspyprofile import Profile
 
 _LOGGER = logging.getLogger("rhasspysupervisor")
@@ -2155,7 +2156,9 @@ def get_text_to_speech(
 
     if tts_system == "wavenet":
 
-        voice = str(profile.get("text_to_speech.wavenet.voice", "en-US-Wavenet-C")).strip()
+        voice = str(
+            profile.get("text_to_speech.wavenet.voice", "en-US-Wavenet-C")
+        ).strip()
         sample_rate = str(profile.get("text_to_speech.wavenet.sample_rate", 22050))
 
         credentials_json = profile.get("text_to_speech.wavenet.credentials_json")


### PR DESCRIPTION
Hi,

In this pull request, I have made changes to the wavenet call.
No longer language_code and gender is used, because it is implicit from the Wavenet Voice that is chosen

The will be a PR for the rhasspy-tts-wavenet-hermes and rhasspy-server-hermes as well, so that wavenet voices are also loaded properly.

Please feel free to comment and discuss, this PR is tightly connected to the other PR's