### PR TITLE
Fix Local Command using ${RHASSPY_PROFILE_DIR}

### DIFF
--- a/rhasspysupervisor/__init__.py
+++ b/rhasspysupervisor/__init__.py
@@ -1872,7 +1872,7 @@ def get_intent_handling(
         if not user_program:
             _LOGGER.error("handle.command.program is required")
             return []
-        
+
         user_program = os.path.expandvars(user_program)
         user_command = [user_program] + command_args(
             profile.get("handle.command.arguments", [])

--- a/rhasspysupervisor/__init__.py
+++ b/rhasspysupervisor/__init__.py
@@ -1872,7 +1872,8 @@ def get_intent_handling(
         if not user_program:
             _LOGGER.error("handle.command.program is required")
             return []
-
+        
+        user_program = os.path.expandvars(user_program)
         user_command = [user_program] + command_args(
             profile.get("handle.command.arguments", [])
         )


### PR DESCRIPTION
Local command handler is currently only working when you use an absolute path.
This line was missing to expand environmental variables in `handler.command.program`.
This should be a fix to issue #50 `Custom command not called`