### PR TITLE
Fix command concatenation

### DIFF
--- a/rhasspysupervisor/__init__.py
+++ b/rhasspysupervisor/__init__.py
@@ -459,8 +459,8 @@ def get_microphone(
         # Command to list available audio input devices
         list_program = profile.get("microphone.command.list_program")
         if list_program:
-            list_command = [list_program] + command_args(
-                profile.get("microphone.command.list_arguments", [])
+            list_command = [list_program] + profile.get(
+                "microphone.command.list_arguments", []
             )
             mic_command.extend(
                 ["--list-command", shlex.quote(" ".join(str(v) for v in list_command))]
@@ -471,8 +471,8 @@ def get_microphone(
         # Command to test available audio input devices
         test_program = profile.get("microphone.command.test_program")
         if test_program:
-            test_command = [test_program] + command_args(
-                profile.get("microphone.command.test_arguments", [])
+            test_command = [test_program] + profile.get(
+                "microphone.command.test_arguments", []
             )
             mic_command.extend(
                 ["--test-command", shlex.quote(" ".join(str(v) for v in test_command))]
@@ -2583,8 +2583,8 @@ def get_speakers(
         # Command to list available audio output devices
         list_program = profile.get("sounds.command.list_program")
         if list_program:
-            list_command = [list_program] + command_args(
-                profile.get("sounds.command.list_arguments", [])
+            list_command = [list_program] + profile.get(
+                "sounds.command.list_arguments", []
             )
             output_command.extend(
                 ["--list-command", shlex.quote(" ".join(str(v) for v in list_command))]

--- a/rhasspysupervisor/__init__.py
+++ b/rhasspysupervisor/__init__.py
@@ -459,8 +459,8 @@ def get_microphone(
         # Command to list available audio input devices
         list_program = profile.get("microphone.command.list_program")
         if list_program:
-            list_command = [list_program] + profile.get(
-                "microphone.command.list_arguments", []
+            list_command = [list_program] + command_args(
+                profile.get("microphone.command.list_arguments", [])
             )
             mic_command.extend(
                 ["--list-command", shlex.quote(" ".join(str(v) for v in list_command))]
@@ -471,8 +471,8 @@ def get_microphone(
         # Command to test available audio input devices
         test_program = profile.get("microphone.command.test_program")
         if test_program:
-            test_command = [test_program] + profile.get(
-                "microphone.command.test_arguments", []
+            test_command = [test_program] + command_args(
+                profile.get("microphone.command.test_arguments", [])
             )
             mic_command.extend(
                 ["--test-command", shlex.quote(" ".join(str(v) for v in test_command))]
@@ -2560,7 +2560,9 @@ def get_speakers(
             _LOGGER.error("sounds.command.play_program is required")
             return []
 
-        play_command = [play_program] + profile.get("sounds.command.play_arguments", [])
+        play_command = [play_program] + command_args(
+            profile.get("sounds.command.play_arguments", [])
+        )
 
         output_command = [
             "rhasspy-speakers-cli-hermes",
@@ -2581,8 +2583,8 @@ def get_speakers(
         # Command to list available audio output devices
         list_program = profile.get("sounds.command.list_program")
         if list_program:
-            list_command = [list_program] + profile.get(
-                "sounds.command.list_arguments", []
+            list_command = [list_program] + command_args(
+                profile.get("sounds.command.list_arguments", [])
             )
             output_command.extend(
                 ["--list-command", shlex.quote(" ".join(str(v) for v in list_command))]


### PR DESCRIPTION
Not super familiar with this codebase yet, but I was running into issues adding a program and arguments to the audio output section:

```
File "/usr/lib/rhasspy/rhasspy-supervisor/rhasspysupervisor/__init__.py", line 2477, in get_speakers
  play_command = [play_program] + profile.get("sounds.command.play_arguments", [])
```

Looks like it was just missing this helper utility. ~Found another couple similar issues as well in the source code, but hadn't tested these flows out in the website.~

Let me know what you think! @synesthesiam @koenvervloesem etc.