### PR TITLE
support for porcupine v2

### DIFF
--- a/rhasspysupervisor/__init__.py
+++ b/rhasspysupervisor/__init__.py
@@ -559,17 +559,25 @@ def get_wake(
     wake_site_id = "default" if not site_ids else site_ids[0]
 
     if wake_system == "porcupine":
+        access_key = profile.get("wake.porcupine.access_key")
+
         keyword = profile.get("wake.porcupine.keyword_path") or "porcupine.ppn"
         if not keyword:
             _LOGGER.error("wake.porcupine.keyword_path required")
             return []
 
+        model_path = profile.get("wake.porcupine.model_path")
+
         sensitivity = profile.get("wake.porcupine.sensitivity", "0.5")
 
         wake_command = [
             "rhasspy-wake-porcupine-hermes",
+            "--access-key",
+            str(access_key),
             "--keyword",
             shlex.quote(str(keyword)),
+            "--model",
+            shlex.quote(str(write_path(profile, "porcupine", model_path))),
             "--sensitivity",
             str(sensitivity),
             "--keyword-dir",


### PR DESCRIPTION
Support for the latest version of Porcupine.

The configuration section in profile.json should look like: 

```
"porcupine": {
  "access_key": "<porcupine-access-key>",
  "keyword_path": "porcupine-keyword-file.ppn",
  "model_path": "porcupine_params.pv"
},
```

This PR is coupled with the following one: https://github.com/rhasspy/rhasspy-wake-porcupine-hermes/pull/11

Until the PRs are merged, the latest porcupine in Rhasspy can be tested by compiling from sources as described [here](https://github.com/asmirnou/rhasspy/wiki#porcupine-v2-support). 